### PR TITLE
Fix build error on older compilers

### DIFF
--- a/src/common/command.hpp
+++ b/src/common/command.hpp
@@ -11,7 +11,7 @@ public:
     static const int INIT = 0, CHECKPOINT = 1, RESTART = 2, TEST = 3;
     
     int unique_id, command, version;
-    char name[MAX_SIZE] = "", original[MAX_SIZE] = "";
+    char name[MAX_SIZE] = {}, original[MAX_SIZE] = {};
 
     command_t() { }
     command_t(int r, int c, int v, const std::string &s) : unique_id(r), command(c), version(v) {


### PR DESCRIPTION
Fix a build error GCC 4.9.3 (and possibly other versions):
```
    command.hpp: In constructor 'command_t::command_t()':
    command.hpp:16:17: error: array used as initializer
        command_t() { }
```
Closes: #9