### PR TITLE
Require Boost 1.53 instead of Boost 1.60

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MODULE_PATH "${VELOC_SOURCE_DIR}/cmake")
 
 # set up boost
 set(Boost_FIND_REQUIRED True)
-find_package(Boost 1.60)
+find_package(Boost 1.53)
 include_directories(${Boost_INCLUDE_DIR})
 
 # set up PThreads


### PR DESCRIPTION
Boost 1.53 is installed on our test machine, and VeloC builds fine with it.  This saves us the trouble of building Boost 1.60 from source (which takes a *long* time) and linking against it.