### PR TITLE
scripts for restart in place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ set(CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_MODULE_PATH "${VELOC_SOURCE_DIR}/cmake")
 
+# Configuration Options
+
+SET(VELOC_RESOURCE_MANAGER "LSF" CACHE STRING "Resource Manager for CLI (SLURM LSF NONE)")
+SET_PROPERTY(CACHE VELOC_RESOURCE_MANAGER PROPERTY STRINGS SLURM LSF NONE)
+
+## PDSH
+FIND_PACKAGE(PDSH REQUIRED)
+
 # set up boost
 set(Boost_FIND_REQUIRED True)
 find_package(Boost 1.53)
@@ -28,6 +36,17 @@ include_directories(${AXL_INCLUDE_DIRS})
 
 find_package(ER REQUIRED)
 include_directories(${ER_INCLUDE_DIRS})
+
+INCLUDE(GNUInstallDirs)
+## Use X_ variable names for CLI scripts
+## could use CMAKE_INSTALL_FULL_ names instead
+SET(X_BINDIR ${CMAKE_INSTALL_FULL_BINDIR} CACHE INTERNAL "bin")
+SET(X_DATADIR ${CMAKE_INSTALL_FULL_DATADIR} CACHE INTERNAL "share")
+SET(X_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR} CACHE INTERNAL "include")
+SET(X_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR} CACHE INTERNAL "lib")
+
+# -----------------------------------------------------------------------------------
+add_subdirectory(scripts)
 
 # -----------------------------------------------------------------------------------
 include_directories(${VELOC_SOURCE_DIR})

--- a/auto-install.py
+++ b/auto-install.py
@@ -82,9 +82,17 @@ if __name__ == "__main__":
         install_dep('https://github.com/ECP-VeloC/redset.git', 'v0.0.4')
         install_dep('https://github.com/ECP-VeloC/er.git', 'v0.0.3')
 
+        # build pdsh
+        pdsh_tarball = wget.download('https://github.com/chaos/pdsh/releases/download/pdsh-2.33/pdsh-2.33.tar.gz', out=args.temp)
+        f = tarfile.open(pdsh_tarball, mode='r:gz')
+        f.extractall(path=args.temp)
+        f.close()
+        os.system("cd {0} && ./configure --prefix={1} --with-mrsh --with-rsh --with-ssh \
+                       && make install".format(args.temp + '/pdsh-2.33', args.prefix))
+    
     # VeloC
-    ret = os.WEXITSTATUS(os.system("cmake -DCMAKE_INSTALL_PREFIX={0} -DCMAKE_BUILD_TYPE={1} {2}\
-                                   && make install".format(args.prefix, cmake_build_type, compiler_options)))
+    ret = os.WEXITSTATUS(os.system("cmake -DCMAKE_INSTALL_PREFIX={0} -DCMAKE_BUILD_TYPE={1} -DWITH_PDSH_PREFIX={2} {3}\
+                                   && make install".format(args.prefix, cmake_build_type, args.prefix, compiler_options)))
 
     # Cleanup
     if (not args.debug):

--- a/cmake/FindPDSH.cmake
+++ b/cmake/FindPDSH.cmake
@@ -1,0 +1,31 @@
+# - Try to find PDSH
+# Once done this will define
+#  PDSH_FOUND - System has pdsh installed
+#  PDSH_EXE - Location of the pdsh binary
+#  DSHBAK_EXE - Location of the dshbak binary
+
+FIND_PATH(WITH_PDSH_PREFIX
+    NAMES bin/pdsh
+)
+
+FIND_PROGRAM(PDSH_EXE
+	NAMES pdsh
+	HINTS ${WITH_PDSH_PREFIX}/bin
+)
+
+FIND_PROGRAM(DSHBAK_EXE
+	NAMES dshbak
+	HINTS ${WITH_PDSH_PREFIX}/bin
+)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PDSH DEFAULT_MSG
+	PDSH_EXE
+	DSHBAK_EXE
+)
+
+# Hide these vars from ccmake GUI
+MARK_AS_ADVANCED(
+	PDSH_EXE
+	DSHBAK_EXE
+)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Function to configure binaries (file.in -> file) and install into bin directory
+# Called from the subdirectories added below
+FUNCTION(VELOC_INSTALL_BIN file)
+	CONFIGURE_FILE(${file}.in ${file} @ONLY)
+	SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/${file}.in PROPERTIES GENERATED FALSE)
+	SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${file} PROPERTIES GENERATED TRUE)
+
+	INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${file} DESTINATION ${CMAKE_INSTALL_BINDIR})
+ENDFUNCTION(VELOC_INSTALL_BIN file)
+
+# Common Binaries
+ADD_SUBDIRECTORY(common)
+
+# Pick the Resource Manager
+SET(cliveloc_dir_name "")
+SET(cliveloc_run_name "")
+
+IF(${VELOC_RESOURCE_MANAGER} STREQUAL "SLURM")
+	SET(cliveloc_dir_name "SLURM")
+	SET(cliveloc_run_name "veloc_srun")
+	LIST(APPEND resource_manager_bins
+		veloc_srun
+	)
+ENDIF(${VELOC_RESOURCE_MANAGER} STREQUAL "SLURM")
+
+IF(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
+	SET(cliveloc_dir_name "LSF")
+	SET(cliveloc_run_name "veloc_jsrun")
+	LIST(APPEND resource_manager_bins
+		veloc_jsrun
+	)
+ENDIF(${VELOC_RESOURCE_MANAGER} STREQUAL "LSF")
+
+IF(${VELOC_RESOURCE_MANAGER} STREQUAL "NONE")
+	MESSAGE("No resource manager selected. Some of the VELOC command line interface will not be built.")
+ELSE(${VELOC_RESOURCE_MANAGER} STREQUAL "NONE")
+	# Each of the following must be implemented for all resource managers
+	LIST(APPEND resource_manager_bins
+		veloc_env
+		veloc_list_down_nodes
+	)
+
+	FOREACH(bin IN ITEMS ${resource_manager_bins})
+		VELOC_INSTALL_BIN(${cliveloc_dir_name}/${bin})
+	ENDFOREACH(bin IN ITEMS ${resource_manager_bins})
+
+	#INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${cliveloc_dir_name}/${cliveloc_run_name} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME ${cliveloc_run_name})
+ENDIF(${VELOC_RESOURCE_MANAGER} STREQUAL "NONE")

--- a/scripts/LSF/veloc_env.in
+++ b/scripts/LSF/veloc_env.in
@@ -1,0 +1,215 @@
+#!/usr/bin/perl -w
+use strict;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+use lib '@X_DATADIR@/veloc';
+use veloc_hostlist;
+
+my $prog = "veloc_env";
+
+my $bin = "@X_BINDIR@";
+my $veloc_nodes_file = "$bin/veloc_nodes_file";
+
+sub print_usage
+{
+  print "\n";
+  print "  Usage:  $prog [options]\n";
+  print "\n";
+  print "  Options:\n";
+  print "    -u, --user     List the username of current job.\n";
+  print "    -j, --jobid    List the job id of the current job.\n";
+  print "    -n, --nodes    List the nodeset the current job is using.\n";
+  print "    -d, --down     List any nodes of the job's nodeset that\n";
+  print "                     the resource managers knows to be down.\n";
+  print "    -p, --prefix   Specify the prefix directory.\n";
+  print "    -r, --runnodes List the number of nodes used in the last run.\n";
+  print "    -e, --endtime  List the end time of the job (secs since epoch).\n";
+  print "    -f, --hostfile <hosts> Echo hostfile subtracting list of <hosts>.\n";
+  print "\n";
+  exit 1;
+}
+
+# read in the command line options
+my %conf = ();
+$conf{user}  = undef;
+$conf{jobid} = undef;
+$conf{nodes} = undef;
+$conf{down}  = undef;
+$conf{prefix}   = undef;
+$conf{runnodes} = undef;
+$conf{endtime}  = undef;
+$conf{hostfile} = undef;
+$conf{help}  = undef;
+my $rc = GetOptions (
+  "user|u"         => \$conf{user},
+  "jobid|j"        => \$conf{jobid},
+  "nodes|n"        => \$conf{nodes},
+  "down|d"         => \$conf{down},
+  "prefix|p=s"     => \$conf{prefix},
+  "runnodes|r"     => \$conf{runnodes},
+  "endtime|e"      => \$conf{endtime},
+  "hostfile|f=s"   => \$conf{hostfile},
+  "help|h"         => \$conf{help},
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+if (defined $conf{user}) {
+  # print the username of the current job
+  if (defined $ENV{USER}) {
+    print "$ENV{USER}\n";
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{jobid}) {
+  # print the jobid of the current job
+  if (defined $ENV{LSB_JOBID}) {
+    print "$ENV{LSB_JOBID}\n";
+  } else {
+    # failed to read jobid from environment,
+    # assume user is running in test mode
+    print "defjobid\n";
+  }
+} elsif (defined $conf{nodes}) {
+  # print the nodeset of the current job in 'atlas[30-33,35,45-53]' form
+  if (defined $ENV{LSB_DJOB_HOSTFILE}) {
+    # LSB_HOSTS would be easier, but it gets truncated at some limit
+    # only reliable way to build this list is to process file specified
+    # by LSB_DJOB_HOSTFILE
+
+    # get the file name and read the file
+    my $hostfile = $ENV{LSB_DJOB_HOSTFILE};
+    my $hoststr = "";
+    if (-r $hostfile) {
+      # got a file, try to read it
+      $hoststr = `cat $hostfile`;
+      if ($? != 0) {
+        # failed to read file
+        exit 1;
+      }
+    }
+
+    # build set of unique hostnames, one hostname per line
+    chomp $hoststr;
+    my @hosts = split('\n', $hoststr);
+    my %hosts_unique;
+    foreach my $host (@hosts) {
+      $hosts_unique{$host} = 1;
+    }
+
+    # compress list and print it
+    my $hostlist = veloc_hostlist::compress(keys %hosts_unique);
+    print "$hostlist\n";
+  } elsif (defined $ENV{LSB_HOSTS}) {
+    my $hostlist = veloc_hostlist::compress($ENV{LSB_HOSTS});
+    print "$hostlist\n";
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{hostfile}) {
+  # get list of down nodes
+  my @downlist = veloc_hostlist::expand($conf{hostfile});
+  my %downhosts;
+  foreach my $host (@downlist) {
+    $downhosts{$host} = 1;
+  }
+  if (defined $ENV{LSB_DJOB_HOSTFILE}) {
+    # LSB_HOSTS would be easier, but it gets truncated at some limit
+    # only reliable way to build this list is to process file specified
+    # by LSB_DJOB_HOSTFILE
+
+    # get the file name and read the file
+    my $hostfile = $ENV{LSB_DJOB_HOSTFILE};
+    my $hoststr = "";
+    if (-r $hostfile) {
+      # got a file, try to read it
+      $hoststr = `cat $hostfile`;
+      if ($? != 0) {
+        # failed to read file
+        exit 1;
+      }
+    }
+
+    # build set of unique hostnames, one hostname per line
+    chomp $hoststr;
+    my @hosts = split('\n', $hoststr);
+    foreach my $host (@hosts) {
+      if (not exists $downhosts{$host}) {
+        print "$host\n";
+      }
+    }
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{down}) {
+  # if the resource manager knows any nodes to be down out of the job's
+  # nodeset, print this list in 'atlas[30-33,35,45-53]' form
+  # if there are none, print nothing, not even a newline
+  if (defined $ENV{LSB_HOSTS}) {
+    # TODO: any way to get list of down nodes in LSF?
+
+    #my $nodeset = $ENV{SLURM_NODELIST};
+    #my $down = `sinfo -ho \%N -t down -n $nodeset`;
+    #if ($? == 0) {
+    #  chomp $down;
+    #  if ($down ne "") {
+    #    print "$down\n";
+    #  }
+    #}
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{runnodes} and defined $conf{prefix}) {
+  # read the nodes file to determine how many nodes the last job ran with
+  my $nodes = `$veloc_nodes_file --dir $conf{prefix}`;
+  if ($? == 0) {
+    chomp $nodes;
+    print "$nodes\n";
+    exit 0;
+  } else {
+    # had a problem executing veloc_nodes_file command
+    print "0\n";
+    exit 1;
+  }
+} elsif (defined $conf{endtime}) {
+  # query bjobs to get time remaining and add to current time
+  my $curtime = time();
+  my $bjobs = `bjobs -o 'time_left'`;
+  if ($? == 0) {
+    my @lines = split("\n", $bjobs);
+    foreach my $line (@lines) {
+      if ($line =~ /^\s*(\d+):(\d+)\s+/) {
+        # the following is printed if there is a limit
+        #   bjobs -o 'time_left'
+        #   TIME_LEFT
+        #   0:12 L
+        # look for a line like "0:12 L",
+        # avoid matching the "L" since other characters can show up there
+        my $hours = $1;
+        my $mins  = $2;
+        my $secs = $curtime + (($hours * 60) + $mins) * 60;
+        print "$secs\n";
+        exit 0;
+      }
+      if ($line =~ /^\-/) {
+        # the following is printed if there is no limit
+        #   bjobs -o 'time_left'
+        #   TIME_LEFT
+        #   -
+        # look for the "-", in this case,
+        # return -1 to indicate there is no limit
+        my $secs = -1;
+        print "$secs\n";
+        exit 0;
+      }
+    }
+  }
+  # had a problem executing bjobs command
+  print "0\n";
+  exit 1;
+} else {
+  # did not specify and option, print the usage
+  print_usage();
+}
+
+exit 0;

--- a/scripts/LSF/veloc_jsrun.in
+++ b/scripts/LSF/veloc_jsrun.in
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# requires: jsrun
+
+launcher="jsrun"
+prog="veloc_${launcher}"
+
+libdir="@X_LIBDIR@"
+bindir="@X_BINDIR@"
+
+# Print usage
+if [ -z "$1" ]; then
+    echo USAGE:
+    echo ""
+    echo "veloc_$launcher <args ...>"
+    echo ""
+    exit 0
+fi
+
+# if VELOC is disabled, just do a normal run and exit
+if [ "$VELOC_ENABLE" == "0" ] ; then
+  $launcher "$@"
+  exit $?
+fi
+
+# turn on verbosity
+if [ -n "$VELOC_DEBUG" ]; then
+  if [ $VELOC_DEBUG -gt 0 ] ; then
+    set -x
+  fi
+fi
+
+# make a record of start time
+timestamp=`date`
+echo "$prog: Started: $timestamp"
+
+# TODO: if not in job allocation, bail out
+jobid=`$bindir/veloc_env --jobid`
+
+# query LSF for job end time, and set variable to read within library
+VELOC_END_TIME=`$bindir/veloc_env --endtime`
+if [ $? -ne 0 ] ; then
+  # failed to get value, so set to 0
+  VELOC_END_TIME=0
+fi
+export VELOC_END_TIME
+
+# get the nodeset of this job
+if [ -z "$VELOC_NODELIST" ] ; then
+  nodelist=`$bindir/veloc_env --nodes`
+  if [ $? -eq 0 ] ; then
+    VELOC_NODELIST=$nodelist
+  fi
+fi
+if [ -z "$VELOC_NODELIST" ] ; then
+  echo "$prog: ERROR: Could not identify nodeset"
+  exit 1
+fi
+export VELOC_NODELIST
+
+# get prefix directory
+prefix=`pwd`
+
+# enter the run loop
+down_nodes=""
+attempts=0
+runs=${VELOC_RETRIES:-0}
+runs=$(($runs + 1))
+runs=${VELOC_RUNS:-$runs}
+while [ 1 ] ; do
+  # once we mark a node as bad, leave it as bad (even if it comes back healthy)
+  # TODO: This hacks around the problem of accidentally deleting a checkpoint set during distribute
+  #       when a relaunch lands on previously down nodes, which are healthy again.
+  #       A better way would be to remember the last set used, or to provide a utility to run on *all*
+  #       nodes to distribute files (also useful for defragging the machine) -- for now this works.
+  keep_down=""
+  if [ "$down_nodes" != "" ] ; then
+    keep_down="--down $down_nodes"
+  fi
+
+  # if this is our first run, check that the free space on the drive meets requirement
+  # (make sure data from job of previous user was cleaned up ok)
+  # otherwise, we'll just check the total capacity
+  free_flag=""
+  if [ $attempts -eq 0 ] ; then
+    free_flag="--free"
+  fi
+
+  # assume we aren't excluding any nodes
+  exclude_hosts=""
+
+  # are there enough nodes to continue?
+  down_nodes=`$bindir/veloc_list_down_nodes $free_flag $keep_down`
+  if [ "$down_nodes" != "" ] ; then
+    # print the reason for the down nodes, and log them
+    $bindir/veloc_list_down_nodes $free_flag $keep_down --reason
+
+    # if this is the first run, we hit down nodes right off the bat, make a record of them
+    if [ $attempts -eq 0 ] ; then
+      start_secs=`date +%s`
+      echo "VELOC: Failed node detected: JOBID=$jobid ATTEMPT=$attempts TIME=$start_secs NNODES=-1 RUNTIME=0 FAILED=$down_nodes"
+    fi
+
+    # determine how many nodes are needed:
+    #   if VELOC_MIN_NODES is set, use that
+    #   otherwise, use value in nodes file if one exists
+    #   otherwise, assume we need all nodes in the allocation
+    # to start, assume we need all nodes in the allocation
+    num_needed=`$bindir/veloc_glob_hosts --count --hosts $VELOC_NODELIST`
+    if [ -n "$VELOC_MIN_NODES" ]  ; then
+      # if VELOC_MIN_NODES is set, use that
+      num_needed=$VELOC_MIN_NODES
+    else
+      # try to lookup the number of nodes used in the last run
+      num_needed_env=`$bindir/veloc_env --prefix $prefix --runnodes`
+      if [ $? -eq 0 ] ; then
+        if [ $num_needed_env -gt 0 ] ; then
+          # if the command worked, and the number is something larger than 0, go with that
+          num_needed=$num_needed_env
+        fi
+      fi
+    fi
+
+    # check that we have enough nodes left to run the job after excluding all down nodes
+    num_left=`$bindir/veloc_glob_hosts --count --minus $VELOC_NODELIST:$down_nodes`
+    if [ $num_left -lt $num_needed ] ; then
+      echo "$prog: (Nodes remaining=$num_left) < (Nodes needed=$num_needed), ending run."
+      break
+    fi
+
+    # assume we aren't excluding any nodes
+    exclude_hosts="--exclude_hosts=$down_nodes"
+  fi
+
+  # make a record of when each run is started
+  attempts=$(($attempts + 1))
+  timestamp=`date`
+  echo "$prog: RUN $attempts: $timestamp"
+
+  # run a job
+  $launcher $exclude_hosts "$@"
+
+  # any retry attempts left?
+  if [ $runs -gt -1 ] ; then
+    runs=$(($runs - 1))
+    if [ $runs -le 0 ] ; then
+      echo "$prog: \$VELOC_RUNS exhausted, ending run."
+      break
+    fi
+  fi
+
+#  # is there a halt condition instructing us to stop?
+#  $bindir/veloc_retries_halt --dir $prefix;
+#  if [ $? == 0 ] ; then
+#    echo "$prog: Halt condition detected, ending run."
+#    break
+#  fi
+
+  # give nodes a chance to clean up
+  sleep 60
+
+#  # check for halt condition again after sleep
+#  $bindir/veloc_retries_halt --dir $prefix;
+#  if [ $? == 0 ] ; then
+#    echo "$prog: Halt condition detected, ending run."
+#    break
+#  fi
+done
+
+# make a record of end time
+timestamp=`date`
+echo "$prog: Ended: $timestamp"

--- a/scripts/LSF/veloc_list_down_nodes.in
+++ b/scripts/LSF/veloc_list_down_nodes.in
@@ -1,0 +1,299 @@
+#!/usr/bin/perl -w
+use strict;
+use lib '@X_DATADIR@/veloc';
+use veloc_hostlist;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+
+my $prog = "veloc_list_down_nodes";
+my $ping = "ping";
+
+my $bindir = "@X_BINDIR@";
+my $pdsh   = "@PDSH_EXE@";
+my $dshbak = "@DSHBAK_EXE@";
+
+my $start_time = time();
+
+my %conf = ();
+
+$conf{usage} = <<EOF
+
+  $prog -- tests and lists nodes that are not available for VELOC
+
+  Usage:  $prog [options] [nodeset]
+
+  Options:
+    -r, --reason
+          Print reason node is down
+    -f, --free
+          Test required drive space based on free amount, rather than capacity
+    -d, --down=NODESET
+          Force nodes to be down without testing
+
+EOF
+;
+
+# print usage and exit
+sub print_usage {
+  print STDOUT $conf{usage};
+  exit 1;
+}
+
+# read in environment variables and command line options
+$conf{reason}       = undef;
+$conf{free}         = undef;
+$conf{nodeset_down} = undef;
+$conf{help}         = undef;
+my $rc = GetOptions (
+  "reason|r"  => \$conf{reason},
+  "free|f"    => \$conf{free},
+  "down|d=s"  => \$conf{nodeset_down},
+  "help|h"    => \$conf{help}
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+# read the nodeset from command line or environment
+my $nodeset = undef;
+if (@ARGV) {
+  $nodeset = shift @ARGV;
+} else {
+  my $nodeset_env = `$bindir/veloc_env --nodes`;
+  if ($? == 0) {
+    chomp $nodeset_env;
+    $nodeset = $nodeset_env;
+  }
+}
+
+# check that we have a nodeset before going any further
+if (not defined $nodeset) {
+  print "$prog: ERROR: Nodeset must be specified or script must be run from within a job allocation.\n";
+  exit(1);
+}
+
+# get list of nodes from nodeset
+my @nodes = veloc_hostlist::expand($nodeset);
+
+# this hash defines all nodes available in our allocation
+my %allocation = ();
+my %available = ();
+foreach my $node (@nodes) {
+  $allocation{$node} = 1;
+  $available{$node} = 1;
+}
+
+# hashes to define all unavailable (down or excluded) nodes and reason
+my %unavailable = ();
+my %reason = ();
+
+# mark the set of nodes the resource manager thinks is down
+my $resmgr_down = `$bindir/veloc_env --down`;
+if ($resmgr_down ne "") {
+  my @resmgr_nodes = veloc_hostlist::expand($resmgr_down);
+  foreach my $node (@resmgr_nodes) {
+    delete $available{$node};
+    $unavailable{$node} = 1;
+    $reason{$node} = "Reported down by resource manager";
+  }
+}
+
+# ping is not supported yet on LSF, rely on pdsh instead
+#
+# mark the set of nodes we can't ping
+#my @failed_ping = ();
+#foreach my $node (@nodes) {
+#  # ICMP over omnipath can fail due to bad arp
+#  # First ping will replenish arp, second succeed
+#  # `ping -c2` will be slower in the "normal" case
+#  # that ping succeeds, because non-root users cannot
+#  # set the ping interval below 0.2 seconds.
+#  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
+#  if ($? != 0) {
+#    delete $available{$node};
+#    $unavailable{$node} = 1;
+#    $reason{$node} = "Failed to ping";
+#  }
+#}
+
+# only run this against set of nodes known to be responding
+my @still_up = (keys %available);
+my $upnodes = veloc_hostlist::compress(@still_up);
+
+# add all up nodes into an assumed down list
+my %pdsh_assumed_down;
+foreach my $node (@still_up) {
+  $pdsh_assumed_down{$node} = 1;
+}
+
+# run an "echo UP" on each node to check whether it works
+if (@still_up > 0) {
+  my $output = `$pdsh -f 256 -w '$upnodes' "echo UP" | $dshbak -c`;
+  my @lines = (split "\n", $output);
+  while (@lines) {
+    my $line = shift @lines;
+    if ($line =~ /^---/) {
+      my $nodeset = shift @lines;
+      $line = shift @lines;
+      my $result = shift @lines;
+      if ($result =~ /UP/) {
+        my @exclude_nodes = veloc_hostlist::expand($nodeset);
+        foreach my $node (@exclude_nodes) {
+          # this node responded, so remove it from the down list
+          delete $pdsh_assumed_down{$node};
+        }
+      }
+    }
+  }
+}
+
+# if we still have any nodes assumed down, update our available/unavailable lists
+foreach my $node (keys %pdsh_assumed_down) {
+  delete $available{$node};
+  $unavailable{$node} = 1;
+  $reason{$node} = "Failed to pdsh echo UP";
+}
+
+# mark any nodes to explicitly exclude via VELOC_EXCLUDE_NODES
+my $exclude = $ENV{"VELOC_EXCLUDE_NODES"};
+if (defined $exclude) {
+  my @exclude_nodes = veloc_hostlist::expand($exclude);
+  foreach my $node (@exclude_nodes) {
+    if (defined $allocation{$node}) {
+      delete $available{$node};
+      $unavailable{$node} = 1;
+      $reason{$node} = "User excluded via VELOC_EXCLUDE_NODES";
+    }
+  }
+}
+
+# mark any nodes specified on the command line
+if (defined $conf{nodeset_down}) {
+  my @exclude_nodes = veloc_hostlist::expand($conf{nodeset_down});
+  foreach my $node (@exclude_nodes) {
+    if (defined $allocation{$node}) {
+      delete $available{$node};
+      $unavailable{$node} = 1;
+      $reason{$node} = "Specified on command line";
+    }
+  }
+}
+
+# TODO: read exclude list from a file, as well?
+
+## specify whether to check total or free capacity in directories
+#my $free_flag = "";
+#if (defined $conf{free}) {
+#  $free_flag = "--free";
+#}
+#
+## check that control and cache directories on each node work and are of proper size
+## get the control directory the job will use
+#my @cntldir_vals = ();
+#my $cntldir_string = `$bindir/veloc_list_dir --base control`;
+#if ($? == 0) {
+#  chomp $cntldir_string;
+#  my @dirs = split(" ", $cntldir_string);
+#  my $cntldirs = $param->get_hash("CNTLDIR");
+#  foreach my $base (@dirs) {
+#    my $val = "$base";
+#    if (defined $cntldirs and defined $$cntldirs{$base} and defined $$cntldirs{$base}{"BYTES"}) {
+#      my $size = (keys %{$$cntldirs{$base}{"BYTES"}})[0];
+#      if (defined $size) {
+#        $val = "$base:$size";
+#      }
+#    }
+#    push @cntldir_vals, $val;
+#  }
+#}
+#my $cntldir_flag = "";
+#if (@cntldir_vals > 0) {
+#  $cntldir_flag = "--cntl " . join(",", @cntldir_vals);
+#}
+#
+## get the cache directory the job will use
+#my @cachedir_vals = ();
+#my $cachedir_string = `$bindir/veloc_list_dir --base cache`;
+#if ($? == 0) {
+#  chomp $cachedir_string;
+#  my @dirs = split(" ", $cachedir_string);
+#  my $cachedirs = $param->get_hash("CACHEDIR");
+#  foreach my $base (@dirs) {
+#    my $val = "$base";
+#    if (defined $cachedirs and defined $$cachedirs{$base} and defined $$cachedirs{$base}{"BYTES"}) {
+#      my $size = (keys %{$$cachedirs{$base}{"BYTES"}})[0];
+#      if (defined $size) {
+#        $val = "$base:$size";
+#      }
+#    }
+#    push @cachedir_vals, $val;
+#  }
+#}
+#my $cachedir_flag = "";
+#if (@cachedir_vals > 0) {
+#  $cachedir_flag = "--cache " . join(",", @cachedir_vals);
+#}
+#
+## only run this against set of nodes known to be responding
+#my @still_up = (keys %available);
+#my $upnodes = veloc_hostlist::compress(@still_up);
+#
+## run veloc_check_node on each node specifying control and cache directories to check
+#if (@still_up > 0) {
+#  my $output = `$pdsh -f 256 -w '$upnodes' "$bindir/veloc_check_node $free_flag $cntldir_flag $cachedir_flag" | $dshbak -c`;
+#  my @lines = (split "\n", $output);
+#  while (@lines) {
+#    my $line = shift @lines;
+#    if ($line =~ /^---/) {
+#      my $nodeset = shift @lines;
+#      $line = shift @lines;
+#      my $result = shift @lines;
+#      if ($result !~ /PASS/) {
+#        my @exclude_nodes = veloc_hostlist::expand($nodeset);
+#        foreach my $node (@exclude_nodes) {
+#          if (defined $allocation{$node}) {
+#            delete $available{$node};
+#            $unavailable{$node} = 1;
+#            $reason{$node} = $result;
+#          }
+#        }
+#      }
+#    }
+#  }
+#}
+
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
+
+# print any failed nodes to stdout and exit with non-zero
+if (@failed_nodes) {
+  # initialize our list of newly failed nodes to be all failed nodes
+  my %newly_failed_nodes = ();
+  foreach my $node (@failed_nodes) {
+    $newly_failed_nodes{$node} = 1;
+  }
+
+  # remove any nodes that user already knew to be down
+  if (defined $conf{nodeset_down}) {
+    my @exclude_nodes = veloc_hostlist::expand($conf{nodeset_down});
+    foreach my $node (@exclude_nodes) {
+      if (defined $newly_failed_nodes{$node}) {
+        delete $newly_failed_nodes{$node};
+      }
+    }
+  }
+
+  # now output info to the user
+  if (defined $conf{reason}) {
+    # list each node and the reason each is down
+    foreach my $node (@failed_nodes) {
+      print "$node: $reason{$node}\n";
+    }
+  } else {
+    # simply print the list of down node in range syntax
+    print veloc_hostlist::compress(@failed_nodes) . "\n";
+  }
+  exit(1);
+}
+
+# otherwise, don't print anything and exit with 0
+exit(0);

--- a/scripts/SLURM/veloc_env.in
+++ b/scripts/SLURM/veloc_env.in
@@ -1,0 +1,107 @@
+#!/usr/bin/perl -w
+use strict;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+use lib '@X_DATADIR@/veloc';
+
+my $prog = "veloc_env";
+
+my $bin = "@X_BINDIR@";
+my $veloc_nodes_file = "$bin/veloc_nodes_file";
+
+sub print_usage
+{
+  print "\n";
+  print "  Usage:  $prog [options]\n";
+  print "\n";
+  print "  Options:\n";
+  print "    -u, --user     List the username of current job.\n";
+  print "    -j, --jobid    List the job id of the current job.\n";
+  print "    -n, --nodes    List the nodeset the current job is using.\n";
+  print "    -d, --down     List any nodes of the job's nodeset that\n";
+  print "                     the resource managers knows to be down.\n";
+  print "    -p, --prefix   Specify the prefix directory.\n";
+  print "    -r, --runnodes List the number of nodes used in the last run.\n";
+  print "\n";
+  exit 1;
+}
+
+# read in the command line options
+my %conf = ();
+$conf{user}  = undef;
+$conf{jobid} = undef;
+$conf{nodes} = undef;
+$conf{down}  = undef;
+$conf{prefix}  = undef;
+$conf{runnodes} = undef;
+$conf{help}  = undef;
+my $rc = GetOptions (
+  "user|u"         => \$conf{user},
+  "jobid|j"        => \$conf{jobid},
+  "nodes|n"        => \$conf{nodes},
+  "down|d"         => \$conf{down},
+  "prefix|p=s"     => \$conf{prefix},
+  "runnodes|r"     => \$conf{runnodes},
+  "help|h"         => \$conf{help},
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+if (defined $conf{user}) {
+  # print the username of the current job
+  if (defined $ENV{USER}) {
+    print "$ENV{USER}\n";
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{jobid}) {
+  # print the jobid of the current job
+  if (defined $ENV{SLURM_JOBID}) {
+    print "$ENV{SLURM_JOBID}\n";
+  } else {
+    # failed to read jobid from environment,
+    # assume user is running in test mode
+    print "defjobid\n";
+  }
+} elsif (defined $conf{nodes}) {
+  # print the nodeset of the current job in 'atlas[30-33,35,45-53]' form
+  if (defined $ENV{SLURM_NODELIST}) {
+    print "$ENV{SLURM_NODELIST}\n";
+    # or, with jobid: squeue -j <jobid> -ho %N
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{down}) {
+  # if the resource manager knows any nodes to be down out of the job's
+  # nodeset, print this list in 'atlas[30-33,35,45-53]' form
+  # if there are none, print nothing, not even a newline
+  if (defined $ENV{SLURM_NODELIST}) {
+    my $nodeset = $ENV{SLURM_NODELIST};
+    my $down = `sinfo -ho \%N -t down -n $nodeset`;
+    if ($? == 0) {
+      chomp $down;
+      if ($down ne "") {
+        print "$down\n";
+      }
+    }
+  } else {
+    exit 1;
+  }
+} elsif (defined $conf{runnodes} and defined $conf{prefix}) {
+  # read the nodes file to determine how many nodes the last job ran with
+  my $nodes = `$veloc_nodes_file --dir $conf{prefix}`;
+  if ($? == 0) {
+    chomp $nodes;
+    print "$nodes\n";
+    exit 0;
+  } else {
+    # had a problem executing veloc_nodes_file command
+    print "0\n";
+    exit 1;
+  }
+} else {
+  # did not specify and option, print the usage
+  print_usage();
+}
+
+exit 0;

--- a/scripts/SLURM/veloc_list_down_nodes.in
+++ b/scripts/SLURM/veloc_list_down_nodes.in
@@ -1,0 +1,261 @@
+#!/usr/bin/perl -w
+use strict;
+use lib '@X_DATADIR@/veloc';
+use veloc_hostlist;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+
+my $prog = "veloc_list_down_nodes";
+my $ping = "ping";
+
+my $bindir = "@X_BINDIR@";
+my $pdsh   = "@PDSH_EXE@";
+my $dshbak = "@DSHBAK_EXE@";
+
+my $start_time = time();
+
+my %conf = ();
+
+$conf{usage} = <<EOF
+
+  $prog -- tests and lists nodes that are not available for VELOC
+
+  Usage:  $prog [options] [nodeset]
+
+  Options:
+    -r, --reason
+          Print reason node is down
+    -f, --free
+          Test required drive space based on free amount, rather than capacity
+    -d, --down=NODESET
+          Force nodes to be down without testing
+
+EOF
+;
+
+# print usage and exit
+sub print_usage {
+  print STDOUT $conf{usage};
+  exit 1;
+}
+
+# read in environment variables and command line options
+$conf{reason}       = undef;
+$conf{free}         = undef;
+$conf{nodeset_down} = undef;
+$conf{help}         = undef;
+my $rc = GetOptions (
+  "reason|r"  => \$conf{reason},
+  "free|f"    => \$conf{free},
+  "down|d=s"  => \$conf{nodeset_down},
+  "help|h"    => \$conf{help}
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+# read the nodeset from command line or environment
+my $nodeset = undef;
+if (@ARGV) {
+  $nodeset = shift @ARGV;
+} else {
+  my $nodeset_env = `$bindir/veloc_env --nodes`;
+  if ($? == 0) {
+    chomp $nodeset_env;
+    $nodeset = $nodeset_env;
+  }
+}
+
+# check that we have a nodeset before going any further
+if (not defined $nodeset) {
+  print "$prog: ERROR: Nodeset must be specified or script must be run from within a job allocation.\n";
+  exit(1);
+}
+
+# get list of nodes from nodeset
+my @nodes = veloc_hostlist::expand($nodeset);
+
+# this hash defines all nodes available in our allocation
+my %allocation = ();
+my %available = ();
+foreach my $node (@nodes) {
+  $allocation{$node} = 1;
+  $available{$node} = 1;
+}
+
+# hashes to define all unavailable (down or excluded) nodes and reason
+my %unavailable = ();
+my %reason = ();
+
+# mark the set of nodes the resource manager thinks is down
+my $resmgr_down = `$bindir/veloc_env --down`;
+if ($resmgr_down ne "") {
+  my @resmgr_nodes = veloc_hostlist::expand($resmgr_down);
+  foreach my $node (@resmgr_nodes) {
+    delete $available{$node};
+    $unavailable{$node} = 1;
+    $reason{$node} = "Reported down by resource manager";
+  }
+}
+
+# mark the set of nodes we can't ping
+my @failed_ping = ();
+foreach my $node (@nodes) {
+  # ICMP over omnipath can fail due to bad arp
+  # First ping will replenish arp, second succeed
+  # `ping -c2` will be slower in the "normal" case
+  # that ping succeeds, because non-root users cannot
+  # set the ping interval below 0.2 seconds.
+  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
+  if ($? != 0) {
+    delete $available{$node};
+    $unavailable{$node} = 1;
+    $reason{$node} = "Failed to ping";
+  }
+}
+
+# mark any nodes to explicitly exclude via VELOC_EXCLUDE_NODES
+my $exclude = $ENV{"VELOC_EXCLUDE_NODES"};
+if (defined $exclude) {
+  my @exclude_nodes = veloc_hostlist::expand($exclude);
+  foreach my $node (@exclude_nodes) {
+    if (defined $allocation{$node}) {
+      delete $available{$node};
+      $unavailable{$node} = 1;
+      $reason{$node} = "User excluded via VELOC_EXCLUDE_NODES";
+    }
+  }
+}
+
+# mark any nodes specified on the command line
+if (defined $conf{nodeset_down}) {
+  my @exclude_nodes = veloc_hostlist::expand($conf{nodeset_down});
+  foreach my $node (@exclude_nodes) {
+    if (defined $allocation{$node}) {
+      delete $available{$node};
+      $unavailable{$node} = 1;
+      $reason{$node} = "Specified on command line";
+    }
+  }
+}
+
+# TODO: read exclude list from a file, as well?
+
+# specify whether to check total or free capacity in directories
+my $free_flag = "";
+if (defined $conf{free}) {
+  $free_flag = "--free";
+}
+
+## check that control and cache directories on each node work and are of proper size
+## get the control directory the job will use
+#my @cntldir_vals = ();
+#my $cntldir_string = `$bindir/veloc_list_dir --base control`;
+#if ($? == 0) {
+#  chomp $cntldir_string;
+#  my @dirs = split(" ", $cntldir_string);
+#  my $cntldirs = $param->get_hash("CNTLDIR");
+#  foreach my $base (@dirs) {
+#    my $val = "$base";
+#    if (defined $cntldirs and defined $$cntldirs{$base} and defined $$cntldirs{$base}{"BYTES"}) {
+#      my $size = (keys %{$$cntldirs{$base}{"BYTES"}})[0];
+#      if (defined $size) {
+#        $size = $param->abtoull($size);
+#        $val = "$base:$size";
+#      }
+#    }
+#    push @cntldir_vals, $val;
+#  }
+#}
+#my $cntldir_flag = "";
+#if (@cntldir_vals > 0) {
+#  $cntldir_flag = "--cntl " . join(",", @cntldir_vals);
+#}
+#
+## get the cache directory the job will use
+#my @cachedir_vals = ();
+#my $cachedir_string = `$bindir/veloc_list_dir --base cache`;
+#if ($? == 0) {
+#  chomp $cachedir_string;
+#  my @dirs = split(" ", $cachedir_string);
+#  my $cachedirs = $param->get_hash("CACHEDIR");
+#  foreach my $base (@dirs) {
+#    my $val = "$base";
+#    if (defined $cachedirs and defined $$cachedirs{$base} and defined $$cachedirs{$base}{"BYTES"}) {
+#      my $size = (keys %{$$cachedirs{$base}{"BYTES"}})[0];
+#      if (defined $size) {
+#        $size = $param->abtoull($size);
+#        $val = "$base:$size";
+#      }
+#    }
+#    push @cachedir_vals, $val;
+#  }
+#}
+#my $cachedir_flag = "";
+#if (@cachedir_vals > 0) {
+#  $cachedir_flag = "--cache " . join(",", @cachedir_vals);
+#}
+#
+## only run this against set of nodes known to be responding
+#my @still_up = (keys %available);
+#my $upnodes = veloc_hostlist::compress(@still_up);
+#
+## run veloc_check_node on each node specifying control and cache directories to check
+#if (@still_up > 0) {
+#  my $output = `$pdsh -Rexec -f 256 -w '$upnodes' srun -n 1 -N 1 -w %h $bindir/veloc_check_node $free_flag $cntldir_flag $cachedir_flag | $dshbak -c`;
+#  my @lines = (split "\n", $output);
+#  while (@lines) {
+#    my $line = shift @lines;
+#    if ($line =~ /^---/) {
+#      my $nodeset = shift @lines;
+#      $line = shift @lines;
+#      my $result = shift @lines;
+#      if ($result !~ /PASS/) {
+#        my @exclude_nodes = veloc_hostlist::expand($nodeset);
+#        foreach my $node (@exclude_nodes) {
+#          if (defined $allocation{$node}) {
+#            delete $available{$node};
+#            $unavailable{$node} = 1;
+#            $reason{$node} = $result;
+#          }
+#        }
+#      }
+#    }
+#  }
+#}
+
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
+
+# print any failed nodes to stdout and exit with non-zero
+if (@failed_nodes) {
+  # initialize our list of newly failed nodes to be all failed nodes
+  my %newly_failed_nodes = ();
+  foreach my $node (@failed_nodes) {
+    $newly_failed_nodes{$node} = 1;
+  }
+
+  # remove any nodes that user already knew to be down
+  if (defined $conf{nodeset_down}) {
+    my @exclude_nodes = veloc_hostlist::expand($conf{nodeset_down});
+    foreach my $node (@exclude_nodes) {
+      if (defined $newly_failed_nodes{$node}) {
+        delete $newly_failed_nodes{$node};
+      }
+    }
+  }
+
+  # now output info to the user
+  if ( defined $conf{reason}) {
+    # list each node and the reason each is down
+    foreach my $node (@failed_nodes) {
+      print "$node: $reason{$node}\n";
+    }
+  } else {
+    # simply print the list of down node in range syntax
+    print veloc_hostlist::compress(@failed_nodes) . "\n";
+  }
+  exit(1);
+}
+
+# otherwise, don't print anything and exit with 0
+exit(0);

--- a/scripts/SLURM/veloc_srun.in
+++ b/scripts/SLURM/veloc_srun.in
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# requires: srun
+
+launcher="srun"
+prog="veloc_${launcher}"
+
+libdir="@X_LIBDIR@"
+bindir="@X_BINDIR@"
+
+# Print usage
+if [ -z "$1" ]; then
+    echo USAGE:
+    echo ""
+    echo "veloc_$launcher <args ...>"
+    echo ""
+    exit 0
+fi
+
+# if VELOC is disabled, just do a normal run and exit
+if [ "$VELOC_ENABLE" == "0" ] ; then
+  $launcher "$@"
+  exit $?
+fi
+
+# turn on verbosity
+if [ -n "$VELOC_DEBUG" ]; then
+  if [ $VELOC_DEBUG -gt 0 ] ; then
+    set -x
+  fi
+fi
+
+# make a record of start time
+timestamp=`date`
+echo "$prog: Started: $timestamp"
+
+# TODO: if not in job allocation, bail out
+
+jobid=`$bindir/veloc_env --jobid`
+
+# get the nodeset of this job
+if [ -z "$VELOC_NODELIST" ] ; then
+  nodelist=`$bindir/veloc_env --nodes`
+  if [ $? -eq 0 ] ; then
+    VELOC_NODELIST=$nodelist
+  fi
+fi
+if [ -z "$VELOC_NODELIST" ] ; then
+  echo "$prog: ERROR: Could not identify nodeset"
+  exit 1
+fi
+export VELOC_NODELIST
+
+# get prefix directory
+prefix=`pwd`
+
+# NOP srun to force every node to run prolog to delete files from cache
+# TODO: remove this if admins find a better place to clear cache
+srun /bin/hostname > /dev/null
+
+# enter the run loop
+down_nodes=""
+attempts=0
+runs=${VELOC_RETRIES:-0}
+runs=$(($runs + 1))
+runs=${VELOC_RUNS:-$runs}
+while [ 1 ] ; do
+  # once we mark a node as bad, leave it as bad (even if it comes back healthy)
+  # TODO: This hacks around the problem of accidentally deleting a checkpoint set during distribute
+  #       when a relaunch lands on previously down nodes, which are healthy again.
+  #       A better way would be to remember the last set used, or to provide a utility to run on *all*
+  #       nodes to distribute files (also useful for defragging the machine) -- for now this works.
+  keep_down=""
+  if [ "$down_nodes" != "" ] ; then
+    keep_down="--down $down_nodes"
+  fi
+
+  # if this is our first run, check that the free space on the drive meets requirement
+  # (make sure data from job of previous user was cleaned up ok)
+  # otherwise, we'll just check the total capacity
+  free_flag=""
+  if [ $attempts -eq 0 ] ; then
+    free_flag="--free"
+  fi
+
+  # are there enough nodes to continue?
+  exclude=""
+  down_nodes=`$bindir/veloc_list_down_nodes $free_flag $keep_down`
+  if [ "$down_nodes" != "" ] ; then
+    # print the reason for the down nodes, and log them
+    $bindir/veloc_list_down_nodes $free_flag $keep_down --reason
+
+    # if this is the first run, we hit down nodes right off the bat, make a record of them
+    if [ $attempts -eq 0 ] ; then
+      start_secs=`date +%s`
+      echo "VELOC: Failed node detected: JOBID=$jobid ATTEMPT=$attempts TIME=$start_secs NNODES=-1 RUNTIME=0 FAILED=$down_nodes"
+    fi
+
+    # determine how many nodes are needed:
+    #   if VELOC_MIN_NODES is set, use that
+    #   otherwise, use value in nodes file if one exists
+    #   otherwise, assume we need all nodes in the allocation
+    # to start, assume we need all nodes in the allocation
+    num_needed=`$bindir/veloc_glob_hosts --count --hosts $VELOC_NODELIST`
+    if [ -n "$VELOC_MIN_NODES" ]  ; then
+      # if VELOC_MIN_NODES is set, use that
+      num_needed=$VELOC_MIN_NODES
+    else
+      # try to lookup the number of nodes used in the last run
+      num_needed_env=`$bindir/veloc_env --prefix $prefix --runnodes`
+      if [ $? -eq 0 ] ; then
+        if [ $num_needed_env -gt 0 ] ; then
+          # if the command worked, and the number is something larger than 0, go with that
+          num_needed=$num_needed_env
+        fi
+      fi
+    fi
+
+    # check that we have enough nodes left to run the job after excluding all down nodes
+    num_left=`$bindir/veloc_glob_hosts --count --minus $VELOC_NODELIST:$down_nodes`
+    if [ $num_left -lt $num_needed ] ; then
+      echo "$prog: (Nodes remaining=$num_left) < (Nodes needed=$num_needed), ending run."
+      break
+    fi
+
+    # all checks pass, exclude the down nodes and continue
+    exclude="--exclude $down_nodes"
+  fi
+
+  # make a record of when each run is started
+  attempts=$(($attempts + 1))
+  timestamp=`date`
+  echo "$prog: RUN $attempts: $timestamp"
+
+  # launch the application
+  $launcher $exclude "$@"
+
+  # any retry attempts left?
+  if [ $runs -gt -1 ] ; then
+    runs=$(($runs - 1))
+    if [ $runs -le 0 ] ; then
+      echo "$prog: \$VELOC_RUNS exhausted, ending run."
+      break
+    fi
+  fi
+
+  # is there a halt condition instructing us to stop?
+#  $bindir/veloc_retries_halt --dir $prefix;
+#  if [ $? == 0 ] ; then
+#    echo "$prog: Halt condition detected, ending run."
+#    break
+#  fi
+
+  # give nodes a chance to clean up
+  sleep 60
+
+  # check for halt condition again after sleep
+#  $bindir/veloc_retries_halt --dir $prefix;
+#  if [ $? == 0 ] ; then
+#    echo "$prog: Halt condition detected, ending run."
+#    break
+#  fi
+done
+
+# make a record of end time
+timestamp=`date`
+echo "$prog: Ended: $timestamp"

--- a/scripts/common/CMakeLists.txt
+++ b/scripts/common/CMakeLists.txt
@@ -1,0 +1,11 @@
+SET(common_bins
+	veloc_check_node
+	veloc_glob_hosts
+)
+
+FOREACH(bin IN ITEMS ${common_bins})
+	VELOC_INSTALL_BIN(${bin})
+ENDFOREACH(bin IN ITEMS ${common_bins})
+
+## Configure & install .pm files
+INSTALL(FILES veloc_hostlist.pm DESTINATION ${CMAKE_INSTALL_DATADIR}/veloc)

--- a/scripts/common/veloc_check_node.in
+++ b/scripts/common/veloc_check_node.in
@@ -1,0 +1,136 @@
+#!/usr/bin/perl -w
+use strict;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+
+# check health of current node
+#   control directory is available and of proper size
+#   cache directory is available and of proper size
+# print PASS if good, and FAIL if not
+
+my $prog = "veloc_check_node";
+
+# define our usage
+sub print_usage
+{
+  print "\n";
+  print "  veloc_check_node -- checks that the current node is healthy\n";
+  print "\n";
+  print "  Usage:  veloc_check_node [--cntl <dir>] [--cache <dir>]\n";
+  print "\n";
+  print "  Options:\n";
+  print "    --free             Check that free capacity of drive meets limit,\n";
+  print "                         checks total capactiy of drive otherwise.\n";
+  print "    --cntl <dir>       Specify the VELOC control directory.\n";
+  print "    --cache <dir>      Specify the VELOC cache directory.\n";
+  print "\n";
+  exit 1;
+}
+
+# read in options specified by user
+my %conf = ();
+$conf{free}       = undef;
+$conf{cntl_list}  = undef;
+$conf{cache_list} = undef;
+$conf{help}  = 0;
+my $rc = GetOptions (
+  "free"    => \$conf{free},
+  "cntl=s"  => \$conf{cntl_list},
+  "cache=s" => \$conf{cache_list},
+  "help|h"  => sub { $conf{help} = 1; },
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+# split up our list of control directories
+if (defined $conf{cntl_list}) {
+  my @dirs = split(",", $conf{cntl_list});
+  foreach my $dir (@dirs) {
+    if ($dir =~ /(.*):(\d+)/) {
+      $conf{cntl}{$1}{bytes} = $2;
+    } else {
+      $conf{cntl}{$dir}{bytes} = undef;
+    }
+  }
+}
+
+# split up our list of cache directories
+if (defined $conf{cache_list}) {
+  my @dirs = split(",", $conf{cache_list});
+  foreach my $dir (@dirs) {
+    if ($dir =~ /(.*):(\d+)/) {
+      $conf{cache}{$1}{bytes} = $2;
+    } else {
+      $conf{cache}{$dir}{bytes} = undef;
+    }
+  }
+}
+
+# check that we can access the directory
+foreach my $type ("cntl", "cache") {
+  my $dir = undef;
+  if (defined $conf{$type}) {
+    my @dirs = (keys %{$conf{$type}});
+
+    # check that we can access the directory (try to run ls on it)
+    foreach my $dir (@dirs) {
+      `ls -lt $dir 2>/dev/null`;
+      if ($? != 0) {
+        print "FAIL: Could not access directory: $dir\n";
+        exit 1;
+      }
+    }
+
+    # if a size is defined, check that the total size is enough
+    foreach my $dir (@dirs) {
+      if (defined $conf{$type}{$dir}{bytes}) {
+        # TODO: need to know which unit df is using
+        # convert expected size from bytes to kilobytes
+        my $kb = int($conf{$type}{$dir}{bytes} / 1024);
+
+        # check total drive capacity, unless --free was given, then check free space on drive
+        my $df_arg_pos = 2;
+        if (defined $conf{free}) {
+          $df_arg_pos = 4;
+        }
+
+        # ok, now get drive capacity
+        my $df_kb = `df -aPk $dir | tail -1 | awk '{print \$$df_arg_pos}' 2>/dev/null`;
+        chomp $df_kb;
+        if ($? != 0) {
+          print "FAIL: Could not access directory: $dir\n";
+          exit 1;
+        }
+
+        # finally, check that capacity meets expected limit from config file
+        if ($df_kb < $kb) {
+          print "FAIL: Insufficient space in directory: $dir, expected $kb KB, found $df_kb KB\n";
+          exit 1;
+        }
+      }
+    }
+
+    # attempt to write to directory
+    foreach my $dir (@dirs) {
+      # define a filename for a test file
+      my $testfile = "$dir/testfile.txt";
+
+      # attempt to touch the test file
+      `touch $testfile`;
+      if ($? != 0) {
+        print "FAIL: Could not touch test file: $testfile\n";
+        exit 1;
+      }
+
+      # attempt to remove the test file
+      `rm -f $testfile`;
+      if ($? != 0) {
+        print "FAIL: Could not rm test file: $testfile\n";
+        exit 1;
+      }
+    }
+  }
+}
+
+print "PASS\n";
+exit 0;

--- a/scripts/common/veloc_glob_hosts.in
+++ b/scripts/common/veloc_glob_hosts.in
@@ -1,0 +1,106 @@
+#!/usr/bin/perl -w
+use strict;
+use lib '@X_DATADIR@/veloc';
+use veloc_hostlist;
+use Getopt::Long qw/ :config gnu_getopt ignore_case /;
+
+my $prog = "veloc_glob_hosts";
+
+sub print_usage
+{
+  print "\n";
+  print "  Usage:  $prog [options]\n";
+  print "\n";
+  print "  Options:\n";
+  print "    -c, --count                 Print the number of hosts.\n";
+  print "    -n, --nth <num>             Output the Nth host (1=lo, -1=hi).\n";
+  print "    -h, --hosts <hosts>         Use this hostlist.\n";
+  print "    -m, --minus <s1:s2>         Elements of s1 not in s2.\n";
+  print "    -i, --intersection <s1:s2>  Intersection of s1 and s2 hosts.\n";
+  print "    -C, --compress <csv hosts>  Compress the csv hostlist\n";
+  print "\n";
+  exit 1;
+}
+
+# read in the command line options
+my %conf = ();
+$conf{count}        = undef;
+$conf{nth}          = undef;
+$conf{hosts}        = undef;
+$conf{minus}        = undef;
+$conf{intersection} = undef;
+$conf{compress}     = undef;
+
+my $rc = GetOptions (
+  "count|c"          => \$conf{count},
+  "nth|n=i"          => \$conf{nth},
+  "hosts|h=s"        => \$conf{hosts},
+  "minus|m=s"        => \$conf{minus},
+  "intersection|i=s" => \$conf{intersection},
+  "compress|C=s"     => \$conf{compress},
+);
+if ($conf{help} or not $rc) {
+  print_usage();
+}
+
+# read the nodeset from command line
+my $valid = undef;
+my @hostset = ();
+if (defined $conf{hosts}) {
+  # user specified precise nodeset to use
+  @hostset = veloc_hostlist::expand($conf{hosts});
+  $valid = 1;
+} elsif (defined $conf{minus}) {
+  # subtract nodes in set2 from set1
+  if ($conf{minus} =~ /^(.*):(.*)$/) {
+    my $h1 = $1;
+    my $h2 = $2;
+    my @set1 = veloc_hostlist::expand($h1);
+    my @set2 = veloc_hostlist::expand($h2);
+    @hostset = veloc_hostlist::diff(\@set1, \@set2);
+    $valid = 1;
+  } else {
+    print_usage();
+  }
+} elsif (defined $conf{intersection}) {
+  # take the intersection of two nodesets
+  if ($conf{intersection} =~ /^(.*):(.*)$/) {
+    my $h1 = $1;
+    my $h2 = $2;
+    my @set1 = veloc_hostlist::expand($h1);
+    my @set2 = veloc_hostlist::expand($h2);
+    @hostset = veloc_hostlist::intersect(\@set1, \@set2);
+    $valid = 1;
+  } else {
+    print_usage();
+  }
+} elsif (defined $conf{compress}) {
+  my @fields = split(",", $conf{compress});
+  print veloc_hostlist::compress(@fields);
+  exit 0;
+}
+
+# if nothing set the nodeset, print usage
+if (not $valid) {
+  print_usage();
+}
+
+# ok, got our resulting nodeset, now print stuff to the screen
+if (defined $conf{nth}) {
+  # print out the nth node of the nodelist
+  my $n = $conf{nth};
+  if ($n == 0 or abs($n) > @hostset) {
+    print "$prog: ERROR: Host index ($n) is out of range for specified host list.\n";
+    exit 1;
+  }
+  if ($n > 0) { $n--; }
+  print $hostset[$n] . "\n";
+} elsif (defined $conf{count}) {
+  # print the number of nodes in the nodelist
+  print scalar(@hostset) . "\n";
+} else {
+  # just print the nodelist
+  print veloc_hostlist::compress(@hostset) . "\n";
+}
+
+exit 0;

--- a/scripts/common/veloc_hostlist.pm
+++ b/scripts/common/veloc_hostlist.pm
@@ -1,0 +1,258 @@
+package veloc_hostlist;
+use strict;
+
+# This package processes slurm-style hostlist strings.
+#
+# expand($hostlist)
+#   returns a list of individual hostnames given a hostlist string
+# compress(@hostlist)
+#   returns an ordered hostlist string given a list of hostnames
+#
+# Author:  Adam Moody (moody20@llnl.gov)
+# modified by Christopher Holguin <christopher.a.holguin@intel.com>
+
+# Returns a list of hostnames given a hostlist string
+# expand("rhea[2-4,6]") returns ('rhea2','rhea3','rhea4','rhea6')
+# hostrange can contain an optional suffix after brackets:
+#   rhea[2-4,6].llnl.gov
+# multiple ranges can be listed as csv:
+#   machine[1-3,5],machine[7-8],machine10
+# left fills with 0 if a host starts with 0:
+#   machine[08-10] --> machine08,machine09,machine10
+sub expand {
+  # read in our hostlist, should be first parameter
+  if (@_ != 1) {
+    return undef;
+  }
+  my $nodeset = shift @_;
+
+  my @nodes = ();
+
+  # split entries on commas
+  # machine[1-3,5],machine[7-8],machine10
+  my @chunks = split ",", $nodeset;
+  while (@chunks > 0) {
+    # look for opening bracket
+    my $chunk = shift @chunks;
+    if ($chunk =~ /^(.*)\[(.*)$/) {
+      # got a starting bracket, scan until we find the closing bracket
+      my $prefix  = $1;
+      my $content = $2;
+      my $suffix  = "";
+
+      # build a list of ranges until we find the closing bracket
+      my @ranges = ();
+      if ($content =~ /^(.*)\](.*)$/) {
+        # found the closing bracket (and optional suffix) in the same chunk
+        push @ranges, $1;
+        $suffix = $2;
+      } else {
+        # no bracket, so we either got a single number or a range here
+        push @ranges, $content;
+
+        # pluck off entries until we find the closing bracket
+        while ($chunks[0] !~ /^(.*)\](.*)$/) {
+          $chunk = shift @chunks;
+          push @ranges, $chunk;
+        }
+
+        # if well formed, this item must now have the bracket
+        $chunk = shift @chunks;
+        if ($chunk =~ /^(.*)\](.*)$/) {
+          # found the closing bracket (and optional suffix)
+          push @ranges, $1;
+          $suffix = $2;
+        }
+      }
+
+      # expand ranges to pairs of low/high values
+      my @lowhighs = ();
+      my $numberLength = 0; # for leading zeros, e.g atlas[0001-0003]
+      foreach my $range (@ranges) {
+        my $low  = undef;
+        my $high = undef;
+        if ($range =~ /(\d+)-(\d+)/) {
+          # low-to-high range
+          $low  = $1;
+          $high = $2;
+        } else {
+          # single element range
+          $low  = $range;
+          $high = $range;
+        }
+        #if the lowest number starts with 0
+        if($numberLength == 0 and index($low,"0") == 0){ 
+           $numberLength = length($low);
+        }
+        push @lowhighs, $low, $high;
+      }
+
+      # produce our list of node names
+      while(@lowhighs) {
+        my $low  = shift @lowhighs;
+        my $high = shift @lowhighs;
+        for(my $i = $low; $i <= $high; $i++) {
+          # tack on leading 0's if input had them
+          my $nodenumber = sprintf("%0*d", $numberLength, $i);
+          my $nodename = $prefix . $nodenumber . $suffix;
+          push @nodes, $nodename;
+        }
+      }
+    } else {
+      # no brackets, just a single node name, copy it verbatim
+      push @nodes, $chunk;
+    }
+  }
+
+  return @nodes;
+}
+
+# Returns a hostlist string given a list of hostnames
+# compress('rhea2','rhea3','rhea4','rhea6') returns "rhea[2-4,6]"
+sub compress_range {
+  if (@_ == 0) {
+    return "";
+  }
+
+  # pull the machine name from the first node name
+  my @numbers = ();
+  my @vmnumbers = ();
+  my ($machine) = ($_[0] =~ /([\D]*)(\d+.*)/);
+  foreach my $host (@_) {
+    # get the machine name and node number for this node
+    my ($name, $number) = ($host =~ /([\D]*)(\d+.*)/);
+
+    # check that all nodes belong to the same machine
+    if ($name ne $machine) {
+      return undef;
+    }
+    my ($temp_comp) = ($number =~ /([\d]+)/);
+    if ( $number eq $temp_comp ){
+        # record the number
+        push @numbers, $number;
+    }
+    else{
+        # we have a machine number with letters attached, so add to 
+        # separate list (we're not going to truly compress these)
+        push @vmnumbers, $machine . $number;
+    }
+
+  }
+
+  # order the nodes by number
+  my @sorted = sort {$a <=> $b} @numbers;
+
+  # TODO: toss out duplicates?
+
+  # build the ranges
+  my @ranges = ();
+  my $low  = $sorted[0];
+  my $last = $low;
+  for(my $i=1; $i < @sorted; $i++) {
+    my $high = $sorted[$i];
+    if($high == $last + 1) {
+      $last = $high;
+      next;
+    }
+    if($last > $low) {
+      push @ranges, $low . "-" . $last;
+    } else {
+      push @ranges, $low;
+    }
+    $low  = $high;
+    $last = $low;
+  }
+  if(@sorted > 0 ){
+      if($last > $low) {
+          push @ranges, $low . "-" . $last;
+      } else {
+          push @ranges, $low;
+      }
+  }
+  my $csv_vals = "";
+  if(@vmnumbers > 0){
+      $csv_vals = ",";
+      $csv_vals .= join(",", @vmnumbers);
+  }
+
+  if(@ranges == 0 && $csv_vals ne ""){
+      return  substr($csv_vals, 1, length($csv_vals));
+  }
+
+  # join the ranges with commas and return the compressed hostlist
+  return $machine . "[" . join(",", @ranges) . "]" . $csv_vals;
+}
+
+# Returns a hostlist string given a list of hostnames
+# compress('rhea2','rhea3','rhea4','rhea6') returns "rhea2,rhea3,rhea4,rhea6"
+sub compress {
+  if (@_ == 0) {
+    return "";
+  }
+
+  # join nodes with commas
+  return join(",", @_);
+}
+
+# Given references to two lists, subtract elements in list 2 from list 1 and return remainder
+sub diff {
+  # we should have two list references
+  if (@_ != 2) {
+    return undef;
+  }
+  my $set1 = $_[0];
+  my $set2 = $_[1];
+
+  my %nodes = ();
+
+  # build list of nodes from set 1
+  foreach my $node (@$set1) {
+    $nodes{$node} = 1;
+  }
+
+  # remove nodes from set 2
+  foreach my $node (@$set2) {
+    delete $nodes{$node};
+  }
+
+  my @nodelist = (keys %nodes);
+  if (@nodelist > 0) {
+    my $list = veloc_hostlist::compress(@nodelist);
+    return veloc_hostlist::expand($list);
+  }
+  return ();
+}
+
+# Given references to two lists, return list of intersection nodes
+sub intersect {
+  # we should have two list references
+  if (@_ != 2) {
+    return undef;
+  }
+  my $set1 = $_[0];
+  my $set2 = $_[1];
+
+  my %nodes = ();
+
+  # build list of nodes from set 1
+  my %tmp_nodes = ();
+  foreach my $node (@$set1) {
+    $tmp_nodes{$node} = 1;
+  }
+
+  # remove nodes from set 2
+  foreach my $node (@$set2) {
+    if (defined $tmp_nodes{$node}) {
+      $nodes{$node} = 1;
+    }
+  }
+
+  my @nodelist = (keys %nodes);
+  if (@nodelist > 0) {
+    my $list = veloc_hostlist::compress(@nodelist);
+    return veloc_hostlist::expand($list);
+  }
+  return ();
+}
+
+1;


### PR DESCRIPTION
Adds scripting for restart-in-place for SLURM and LSF resource managers.  Detects down nodes and computes remaining healthy set of nodes.  Constructs new launch command excluding down nodes.

- user can set VELOC_RUNS variable to define max limit of number of run attempts, -1 means no limit
- user can set VELOC_DEBUG=1 to echo script commands
- uses pdsh and dshbak to run tests on healthy compute nodes