### PR TITLE
Set pdsh rcmd module to ssh

### DIFF
--- a/scripts/LSF/veloc_list_down_nodes.in
+++ b/scripts/LSF/veloc_list_down_nodes.in
@@ -127,7 +127,7 @@ foreach my $node (@still_up) {
 
 # run an "echo UP" on each node to check whether it works
 if (@still_up > 0) {
-  my $output = `$pdsh -f 256 -w '$upnodes' "echo UP" | $dshbak -c`;
+  my $output = `$pdsh -R ssh -f 256 -w '$upnodes' "echo UP" | $dshbak -c`;
   my @lines = (split "\n", $output);
   while (@lines) {
     my $line = shift @lines;


### PR DESCRIPTION
The restart-in-place scripts for LSF use `pdsh`. Without `-R ssh`, `pdsh` fails with
```
mcmd: xpoll: protocol failure in circuit setup
```
for "non-privileged" users. 